### PR TITLE
chore: cleanup mojibake text and harden project link schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # Portfolio + Sanity Studio
 
 ## Local development
-- Node `20.19.x` (`.nvmrc`), npm `>=10`.
+- Node `22.11.x` (`.nvmrc`), npm `>=10`.
 - Frontend (Vite):
   - Install: `npm install`
-  - Dev: `npm start` (http://localhost:3000)
+  - Dev: `npm start` (http://localhost:3000, configured in `vite.config.mjs`)
   - Build: `npm run build` (outputs to `dist/`)
 - Sanity Studio (v5, `studio13/`):
   - Install: `cd studio13 && npm install`
@@ -20,10 +20,11 @@
 - Keep secrets out of git; use `.env` locally and Netlify environment variables in production.
 - Use VS Code with the recommended extensions (`.vscode/extensions.json`) and format-on-save settings (`.vscode/settings.json`).
 - Minesweeper source viewer is served from `public/code/minesweeper-source.html` and fetches the raw file from GitHub.
-- If Sanity data fails to load locally, ensure CORS allows `http://127.0.0.1:5173` and `http://localhost:5173`:
+- If Sanity data fails to load locally, ensure CORS allows `http://127.0.0.1:3000` and `http://localhost:3000`:
   - `cd studio13`
   - `npx.cmd sanity login`
-  - `npm run cors:add-local`
+  - `npx.cmd sanity cors add http://127.0.0.1:3000 --credentials`
+  - `npx.cmd sanity cors add http://localhost:3000 --credentials`
   - Keep the Netlify URL in the Sanity CORS list as well.
 
 ## CRA -> Vite migration plan (complete)

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,6 @@
       "name": "portfolio",
       "version": "0.1.0",
       "dependencies": {
-        "@sanity/block-content-to-react": "^3.0.0",
         "@sanity/client": "^7.13.2",
         "react": "19.2.4",
         "react-dom": "19.2.4",
@@ -1419,31 +1418,6 @@
         "win32"
       ]
     },
-    "node_modules/@sanity/block-content-to-hyperscript": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@sanity/block-content-to-hyperscript/-/block-content-to-hyperscript-3.0.1.tgz",
-      "integrity": "sha512-g61ogB8s94T5ellKMtnoN1wW9mCqy1foS9jw5QaRAQZUk7ANIwT2YNFqfAj6xF9YiMXcoaKTqDa/JzKeGMpJHA==",
-      "license": "MIT",
-      "dependencies": {
-        "@sanity/generate-help-url": "^0.140.0",
-        "@sanity/image-url": "^0.140.15",
-        "hyperscript": "^2.0.2",
-        "object-assign": "^4.1.1"
-      }
-    },
-    "node_modules/@sanity/block-content-to-react": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@sanity/block-content-to-react/-/block-content-to-react-3.0.0.tgz",
-      "integrity": "sha512-oHPLlIsulsnL3ITs93RIvUPBI6nAeoSFOUf16vX4T7z4wWywxP39N1DF9mAx2tV6Kjr1fJAx5GF7zfiMXYLaqA==",
-      "license": "MIT",
-      "dependencies": {
-        "@sanity/block-content-to-hyperscript": "^3.0.0",
-        "prop-types": "^15.6.2"
-      },
-      "peerDependencies": {
-        "react": ">=15.0.0"
-      }
-    },
     "node_modules/@sanity/client": {
       "version": "7.16.0",
       "resolved": "https://registry.npmjs.org/@sanity/client/-/client-7.16.0.tgz",
@@ -1469,21 +1443,6 @@
         "@types/eventsource": "1.1.15",
         "event-source-polyfill": "1.0.31",
         "eventsource": "2.0.2"
-      }
-    },
-    "node_modules/@sanity/generate-help-url": {
-      "version": "0.140.0",
-      "resolved": "https://registry.npmjs.org/@sanity/generate-help-url/-/generate-help-url-0.140.0.tgz",
-      "integrity": "sha512-H/G/WA9S22TXcXST52CIiTsHx3S2hH0gvK7LnI5w76vfKS0obnDPh8jrPg4xeNRYGPuV9MHYRlyERGpRGoo4Qw==",
-      "license": "MIT"
-    },
-    "node_modules/@sanity/image-url": {
-      "version": "0.140.22",
-      "resolved": "https://registry.npmjs.org/@sanity/image-url/-/image-url-0.140.22.tgz",
-      "integrity": "sha512-CAmQZnj+KM7FSEYiWlIGDit072syicYuAw0w7R2ctMzHiZ4p9mE/g6dBnYqrqFUrw2J+GpJgPt+RVspKP8vdqA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.0.0"
       }
     },
     "node_modules/@standard-schema/spec": {
@@ -2242,12 +2201,6 @@
         "require-from-string": "^2.0.2"
       }
     },
-    "node_modules/browser-split": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/browser-split/-/browser-split-0.0.0.tgz",
-      "integrity": "sha512-CNXO3AXAS1H/kOGQkPjucm1161/XoF3aVkMfujqwk85XN/D/MkQMvoB81lXyX/2rerZS+hPAYYRR3mAW05awjQ==",
-      "license": "MIT"
-    },
     "node_modules/browserslist": {
       "version": "4.28.1",
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.1.tgz",
@@ -2312,14 +2265,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
-      }
-    },
-    "node_modules/class-list": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/class-list/-/class-list-0.1.1.tgz",
-      "integrity": "sha512-zqR0uW+VsLtyQhixBhkdQ+z6B8+Y8HTh28kdSVjJ4zTTKM7Xz2asAQSya9VI6m/34F6N6Ktm0mrchKB+E5a8Xw==",
-      "dependencies": {
-        "indexof": "0.0.1"
       }
     },
     "node_modules/convert-source-map": {
@@ -2687,18 +2632,6 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/html-element": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/html-element/-/html-element-2.3.1.tgz",
-      "integrity": "sha512-xnFt2ZkbFcjc+JoAtg3Hl89VeEZDjododu4VCPkRvFmBTHHA9U1Nt6hLUWfW2O+6Sl/rT1hHK/PivleX3PdBJQ==",
-      "license": "MIT",
-      "dependencies": {
-        "class-list": "~0.1.1"
-      },
-      "engines": {
-        "node": ">=4.2"
-      }
-    },
     "node_modules/html-encoding-sniffer": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
@@ -2739,22 +2672,6 @@
       "engines": {
         "node": ">= 14"
       }
-    },
-    "node_modules/hyperscript": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/hyperscript/-/hyperscript-2.0.2.tgz",
-      "integrity": "sha512-uggBAYfHFC5WyZQXlJ61BNZbPmJbschcvfYNhYdZWCp+0J8KYb5Du8nQuk8Ru+ThoCNb01B0tPtnTRqnrFBkVg==",
-      "license": "MIT",
-      "dependencies": {
-        "browser-split": "0.0.0",
-        "class-list": "~0.1.0",
-        "html-element": "^2.0.0"
-      }
-    },
-    "node_modules/indexof": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz",
-      "integrity": "sha512-i0G7hLJ1z0DE8dsqJa2rycj9dBmNKgXBvotXtZYXakU9oivfB9Uj2ZBC27qqef2U58/ZLwalxa1X/RDCdkHtVg=="
     },
     "node_modules/inherits": {
       "version": "2.0.4",
@@ -3243,15 +3160,6 @@
         "npm": ">=8.12.1"
       }
     },
-    "node_modules/object-assign": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/obug": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
@@ -3355,23 +3263,6 @@
       "engines": {
         "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
       }
-    },
-    "node_modules/prop-types": {
-      "version": "15.8.1",
-      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
-      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
-      "license": "MIT",
-      "dependencies": {
-        "loose-envify": "^1.4.0",
-        "object-assign": "^4.1.1",
-        "react-is": "^16.13.1"
-      }
-    },
-    "node_modules/prop-types/node_modules/react-is": {
-      "version": "16.13.1",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "license": "MIT"
     },
     "node_modules/punycode": {
       "version": "2.3.1",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,6 @@
     "npm": ">=10"
   },
   "dependencies": {
-    "@sanity/block-content-to-react": "^3.0.0",
     "@sanity/client": "^7.13.2",
     "react": "19.2.4",
     "react-dom": "19.2.4",

--- a/src/components/Home.jsx
+++ b/src/components/Home.jsx
@@ -8,9 +8,12 @@ import Seo, {
   SOCIAL_LINKS,
 } from "./Seo";
 
+const CHECKMARK_SYMBOL = "\u2713";
+
 const fallbackContent = {
   title: "Berin Karjala",
-  roleLabel: "Full-Stack Developer • QA-Minded Engineer • UX-Aware Builder",
+  roleLabel:
+    "Full-Stack Developer \u2022 QA-Minded Engineer \u2022 UX-Aware Builder",
   heroParagraph:
     "I design and build calm, reliable digital experiences rooted in clarity, structure, and long-term maintainability. My background spans software quality assurance, front-end development, and systems-focused problem solving, allowing me to bridge clean user interfaces with dependable technical foundations.",
   heroSupportingLine:
@@ -50,7 +53,7 @@ const fallbackContent = {
   ],
   howIWorkHeading: "How I Work",
   howIWorkBody:
-    "I bring a quality-first mindset shaped by years of working in structured, high-compliance environments. Whether I’m writing UI code, refining content models, or validating workflows, I focus on building systems that are calm, predictable, and easy to maintain.\n\nMy background in software QA, operations coordination, and technical support informs every development decision I make. I value clear communication, careful verification, and solutions that hold up over time.",
+    "I bring a quality-first mindset shaped by years of working in structured, high-compliance environments. Whether I'm writing UI code, refining content models, or validating workflows, I focus on building systems that are calm, predictable, and easy to maintain.\n\nMy background in software QA, operations coordination, and technical support informs every development decision I make. I value clear communication, careful verification, and solutions that hold up over time.",
   currentlyOpenToHeading: "Currently Open To",
   currentlyOpenToBullets: [
     "Full-time frontend or full-stack roles",
@@ -163,7 +166,7 @@ export default function Home() {
                   <ul className="mt-2 space-y-2 text-green-100 text-sm">
                     {strengthGroup.bullets.map((bullet) => (
                       <li key={bullet} className="flex gap-2">
-                        <span className="text-green-300">✓</span>
+                        <span className="text-green-300">{CHECKMARK_SYMBOL}</span>
                         <span>{bullet}</span>
                       </li>
                     ))}
@@ -237,7 +240,7 @@ export default function Home() {
               <ul className="mt-3 space-y-2 text-green-100 text-sm text-left">
                 {content.currentlyOpenToBullets.map((bullet) => (
                   <li key={bullet} className="flex gap-2">
-                    <span className="text-green-300">✓</span>
+                    <span className="text-green-300">{CHECKMARK_SYMBOL}</span>
                     <span>{bullet}</span>
                   </li>
                 ))}

--- a/src/components/projects/Minesweeper.jsx
+++ b/src/components/projects/Minesweeper.jsx
@@ -4,8 +4,8 @@ import Seo, { SITE_NAME, SITE_URL } from "../Seo";
 const DEBUG_VALIDATE_COUNTS = false;
 const PAGE_DESCRIPTION =
   "Play a classic Minesweeper board and explore the game logic behind the scenes.";
-const FLAG_SYMBOL = "🚩";
-const BOMB_SYMBOL = "💣";
+const FLAG_SYMBOL = "\u{1F6A9}";
+const BOMB_SYMBOL = "\u{1F4A3}";
 
 class Minsweeper extends Component {
   constructor(props) {

--- a/studio13/schemas/project.js
+++ b/studio13/schemas/project.js
@@ -30,7 +30,11 @@ export default defineType({
     }),
     defineField({
       name: "link",
-      type: "string",
+      type: "url",
+      validation: (Rule) =>
+        Rule.uri({
+          scheme: ["http", "https"],
+        }),
     }),
   ],
 });

--- a/vite.config.mjs
+++ b/vite.config.mjs
@@ -13,7 +13,7 @@ export default defineConfig({
         manualChunks: {
           react: ['react', 'react-dom'],
           router: ['react-router-dom'],
-          sanity: ['@sanity/client', '@sanity/block-content-to-react'],
+          sanity: ['@sanity/client'],
           helmet: ['react-helmet-async'],
           icons: ['react-icons'],
         },


### PR DESCRIPTION
## Summary
- normalize mojibake-prone fallback/default text in Home and Minesweeper without changing UI behavior
- remove unused `@sanity/block-content-to-react` and clean stale Vite chunk reference
- harden `studio13` project schema `link` field to `url` with `http/https` validation
- align local development docs with verified Node 22.11.x and Vite port 3000

## Checklist
- [x] baseline verified
- [x] scope respected
- [x] validations run
  - `npm.cmd test`
  - `npm.cmd run build`
  - `npm.cmd --prefix studio13 run build`
- [x] files changed
  - `README.md`
  - `package.json`
  - `package-lock.json`
  - `src/components/Home.jsx`
  - `src/components/projects/Minesweeper.jsx`
  - `studio13/schemas/project.js`
  - `vite.config.mjs`
- [x] risks / TODOs
  - `studio13/package.json` script `cors:add-local` still targets port 5173; README now documents explicit 3000 CORS commands to match the current Vite config.
- [x] local acceptance testing completed before merge to `main`

Localized acceptance testing is required before merging this PR to `main`.
