### PR TITLE
fix: harden projects page loading and background preloading

### DIFF
--- a/src/components/Project.jsx
+++ b/src/components/Project.jsx
@@ -3,8 +3,14 @@ import sanityClient from "../client.js";
 import Seo, { SITE_NAME, SITE_URL } from "./Seo";
 import { cancelIdle, runWhenIdle } from "../utils/idleCallback";
 
+const EMPTY_PROJECTS = [];
+const EMPTY_PROJECT_DESCRIPTION =
+  "Project details are temporarily unavailable. Please check back shortly.";
+
 export default function Project() {
-  const [projectData, setProjectData] = useState(null);
+  const [projectData, setProjectData] = useState(EMPTY_PROJECTS);
+  const [isLoading, setIsLoading] = useState(true);
+  const [hasFetchError, setHasFetchError] = useState(false);
 
   useEffect(() => {
     let isActive = true;
@@ -25,10 +31,22 @@ export default function Project() {
         )
         .then((data) => {
           if (isActive) {
-            setProjectData(data);
+            setProjectData(Array.isArray(data) ? data : EMPTY_PROJECTS);
+            setHasFetchError(false);
           }
         })
-        .catch(console.error);
+        .catch((error) => {
+          console.error(error);
+          if (isActive) {
+            setProjectData(EMPTY_PROJECTS);
+            setHasFetchError(true);
+          }
+        })
+        .finally(() => {
+          if (isActive) {
+            setIsLoading(false);
+          }
+        });
     });
 
     return () => {
@@ -37,10 +55,23 @@ export default function Project() {
     };
   }, []);
 
-  const projects = Array.isArray(projectData) ? projectData : [];
+  if (isLoading) {
+    return (
+      <main className="relative forest-bg text-green-50">
+        <section className="container mx-auto px-4 sm:px-6 md:px-8 py-8 sm:py-10 flex justify-center relative z-10">
+          <div className="w-full max-w-5xl bg-green-900 bg-opacity-40 border border-green-700 border-opacity-40 rounded-2xl shadow-2xl backdrop-filter backdrop-blur-sm p-4 sm:p-8 lg:p-10">
+            <p className="text-sm uppercase tracking-widest text-green-200">
+              Loading...
+            </p>
+          </div>
+        </section>
+      </main>
+    );
+  }
+
+  const projects = projectData.filter((project) => project?.name && project?.link);
   const projectNames = projects
     .map((project) => project?.name)
-    .filter(Boolean)
     .slice(0, 3);
   const pageDescription = projectNames.length
     ? `Projects by ${SITE_NAME}, including ${projectNames.join(", ")}.`
@@ -93,6 +124,12 @@ export default function Project() {
             <p className="uppercase tracking-widest text-xs sm:text-sm text-green-200 text-center">
               Selected work and experiments
             </p>
+            {hasFetchError ? (
+              <p className="mt-4 text-sm text-amber-200">
+                Could not load the latest project content from Sanity. Showing
+                fallback content.
+              </p>
+            ) : null}
             <div className="mt-4 space-y-4 text-green-100 leading-relaxed max-w-3xl">
               <p>
                 A curated set of projects focused on UI clarity, reliable behavior,
@@ -104,11 +141,8 @@ export default function Project() {
                 Projects
               </h2>
               <div className="mt-4 grid grid-cols-1 md:grid-cols-2 gap-4 sm:gap-6">
-                {projects.map((project) => {
-                  if (!project?.link || !project?.name) {
-                    return null;
-                  }
-                  return (
+                {projects.length > 0 ? (
+                  projects.map((project) => (
                     <a
                       key={`${project.name}-${project.link}`}
                       href={project.link}
@@ -117,26 +151,39 @@ export default function Project() {
                       aria-label={`View project: ${project.name}`}
                       className="block h-full border border-green-700 border-opacity-30 bg-green-900 bg-opacity-30 rounded-2xl p-4 sm:p-5 shadow-lg backdrop-filter backdrop-blur-sm transition hover:bg-opacity-40 hover:shadow-xl focus:outline-none focus-visible:ring-2 focus-visible:ring-green-400 focus-visible:ring-offset-2 focus-visible:ring-offset-green-900"
                     >
-                      {project.thumbnail?.asset?.url ? (
-                        <img
-                          src={project.thumbnail.asset.url}
-                          alt={project.thumbnail.alt || project.name}
-                          className="w-full h-36 sm:h-40 rounded-lg object-cover"
-                          width="640"
-                          height="360"
-                          loading="lazy"
-                          decoding="async"
-                        />
-                      ) : null}
+                      <div
+                        className="w-full overflow-hidden rounded-lg border border-green-700 border-opacity-30 bg-green-900 bg-opacity-40"
+                        style={{ aspectRatio: "16 / 9" }}
+                      >
+                        {project.thumbnail?.asset?.url ? (
+                          <img
+                            src={project.thumbnail.asset.url}
+                            alt={project.thumbnail.alt || project.name}
+                            className="h-full w-full object-cover"
+                            width="640"
+                            height="360"
+                            loading="lazy"
+                            decoding="async"
+                          />
+                        ) : (
+                          <div className="flex h-full w-full items-center justify-center px-4 text-center text-sm font-semibold text-green-200">
+                            Preview unavailable
+                          </div>
+                        )}
+                      </div>
                       <h3 className="mt-4 text-base sm:text-lg font-semibold text-green-100">
                         {project.name}
                       </h3>
                       <p className="mt-2 text-green-100 text-sm leading-relaxed">
-                        {project.description}
+                        {project.description || EMPTY_PROJECT_DESCRIPTION}
                       </p>
                     </a>
-                  );
-                })}
+                  ))
+                ) : (
+                  <div className="md:col-span-2 rounded-2xl border border-green-700 border-opacity-30 bg-green-900 bg-opacity-30 p-5 text-sm text-green-100 shadow-lg backdrop-filter backdrop-blur-sm">
+                    No project entries are available right now.
+                  </div>
+                )}
               </div>
             </div>
           </div>

--- a/src/components/Project.jsx
+++ b/src/components/Project.jsx
@@ -55,20 +55,6 @@ export default function Project() {
     };
   }, []);
 
-  if (isLoading) {
-    return (
-      <main className="relative forest-bg text-green-50">
-        <section className="container mx-auto px-4 sm:px-6 md:px-8 py-8 sm:py-10 flex justify-center relative z-10">
-          <div className="w-full max-w-5xl bg-green-900 bg-opacity-40 border border-green-700 border-opacity-40 rounded-2xl shadow-2xl backdrop-filter backdrop-blur-sm p-4 sm:p-8 lg:p-10">
-            <p className="text-sm uppercase tracking-widest text-green-200">
-              Loading...
-            </p>
-          </div>
-        </section>
-      </main>
-    );
-  }
-
   const projects = projectData.filter((project) => project?.name && project?.link);
   const projectNames = projects
     .map((project) => project?.name)
@@ -76,6 +62,9 @@ export default function Project() {
   const pageDescription = projectNames.length
     ? `Projects by ${SITE_NAME}, including ${projectNames.join(", ")}.`
     : "Selected projects focused on UI clarity, reliable behavior, and thoughtful technical execution.";
+  const emptyStateMessage = hasFetchError
+    ? "Project entries are temporarily unavailable right now."
+    : "No project entries are available right now.";
   const ogImage = projects.find((project) => project?.thumbnail?.asset?.url)
     ?.thumbnail?.asset?.url;
   const webPageSchema = {
@@ -126,8 +115,7 @@ export default function Project() {
             </p>
             {hasFetchError ? (
               <p className="mt-4 text-sm text-amber-200">
-                Could not load the latest project content from Sanity. Showing
-                fallback content.
+                Could not load the latest project content from Sanity.
               </p>
             ) : null}
             <div className="mt-4 space-y-4 text-green-100 leading-relaxed max-w-3xl">
@@ -141,7 +129,11 @@ export default function Project() {
                 Projects
               </h2>
               <div className="mt-4 grid grid-cols-1 md:grid-cols-2 gap-4 sm:gap-6">
-                {projects.length > 0 ? (
+                {isLoading ? (
+                  <div className="md:col-span-2 rounded-2xl border border-green-700 border-opacity-30 bg-green-900 bg-opacity-30 p-5 text-sm uppercase tracking-widest text-green-200 shadow-lg backdrop-filter backdrop-blur-sm">
+                    Loading project entries...
+                  </div>
+                ) : projects.length > 0 ? (
                   projects.map((project) => (
                     <a
                       key={`${project.name}-${project.link}`}
@@ -181,7 +173,7 @@ export default function Project() {
                   ))
                 ) : (
                   <div className="md:col-span-2 rounded-2xl border border-green-700 border-opacity-30 bg-green-900 bg-opacity-30 p-5 text-sm text-green-100 shadow-lg backdrop-filter backdrop-blur-sm">
-                    No project entries are available right now.
+                    {emptyStateMessage}
                   </div>
                 )}
               </div>

--- a/src/components/Project.test.jsx
+++ b/src/components/Project.test.jsx
@@ -1,0 +1,83 @@
+/* @vitest-environment jsdom */
+import { render, screen, waitFor } from "@testing-library/react";
+import { HelmetProvider } from "react-helmet-async";
+import { MemoryRouter } from "react-router-dom";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { cancelIdleMock, fetchMock } = vi.hoisted(() => ({
+  cancelIdleMock: vi.fn(),
+  fetchMock: vi.fn(),
+}));
+
+vi.mock("../client.js", () => ({
+  default: {
+    fetch: fetchMock,
+  },
+}));
+
+vi.mock("../utils/idleCallback", () => ({
+  cancelIdle: cancelIdleMock,
+  runWhenIdle: (callback) => {
+    callback();
+    return "idle-handle";
+  },
+}));
+
+import Project from "./Project";
+
+const renderProject = () =>
+  render(
+    <HelmetProvider>
+      <MemoryRouter initialEntries={["/project"]}>
+        <Project />
+      </MemoryRouter>
+    </HelmetProvider>
+  );
+
+describe("Project", () => {
+  beforeEach(() => {
+    fetchMock.mockReset();
+    cancelIdleMock.mockReset();
+    document.title = "";
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("keeps the page shell and SEO metadata visible while projects are loading", async () => {
+    fetchMock.mockImplementation(() => new Promise(() => {}));
+
+    renderProject();
+
+    expect(
+      screen.getByRole("heading", {
+        name: /my projects/i,
+      })
+    ).not.toBeNull();
+    expect(screen.getByText(/loading project entries/i)).not.toBeNull();
+
+    await waitFor(() => {
+      expect(document.title).toBe("Projects | Berin Karjala");
+    });
+  });
+
+  it("shows the fetch error state without claiming fallback entries exist", async () => {
+    const consoleErrorSpy = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined);
+    fetchMock.mockRejectedValueOnce(new Error("Sanity unavailable"));
+
+    renderProject();
+
+    expect(
+      await screen.findByText(/could not load the latest project content from sanity/i)
+    ).not.toBeNull();
+    expect(
+      screen.getByText(/project entries are temporarily unavailable right now/i)
+    ).not.toBeNull();
+    expect(screen.queryByText(/showing fallback content/i)).toBeNull();
+
+    consoleErrorSpy.mockRestore();
+  });
+});

--- a/src/preloadBackground.js
+++ b/src/preloadBackground.js
@@ -1,5 +1,8 @@
 import forestAvif1600 from "./forest-waterfall-1600.avif";
+import forestAvif2400 from "./forest-waterfall-2400.avif";
 import forestWebp1600 from "./forest-waterfall-1600.webp";
+import forestWebp2400 from "./forest-waterfall-2400.webp";
+import forestPng from "./forest-waterfall.png";
 
 const supportsAvif = () =>
   new Promise((resolve) => {
@@ -19,6 +22,9 @@ const supportsWebp = () =>
       "data:image/webp;base64,UklGRiIAAABXRUJQVlA4TBEAAAAvAAAAAAfQ//73v/+BiOh/AAA=";
   });
 
+const shouldUseHighDensityAsset = () =>
+  typeof window !== "undefined" && (window.devicePixelRatio || 1) > 1.5;
+
 const preloadBackgroundImage = async () => {
   if (typeof document === "undefined") {
     return;
@@ -28,6 +34,7 @@ const preloadBackgroundImage = async () => {
     return;
   }
 
+  const useHighDensityAsset = shouldUseHighDensityAsset();
   const canUseAvif = await supportsAvif();
   const canUseWebp = !canUseAvif && (await supportsWebp());
 
@@ -35,13 +42,14 @@ const preloadBackgroundImage = async () => {
   link.rel = "preload";
   link.as = "image";
   if (canUseAvif) {
-    link.href = forestAvif1600;
+    link.href = useHighDensityAsset ? forestAvif2400 : forestAvif1600;
     link.type = "image/avif";
   } else if (canUseWebp) {
-    link.href = forestWebp1600;
+    link.href = useHighDensityAsset ? forestWebp2400 : forestWebp1600;
     link.type = "image/webp";
   } else {
-    return;
+    link.href = forestPng;
+    link.type = "image/png";
   }
   link.setAttribute("fetchpriority", "high");
   link.setAttribute("data-bg-preload", "forest");


### PR DESCRIPTION
## Summary
- harden the Projects page with explicit loading, fetch-error, and empty states
- reserve project thumbnail space even when Sanity entries do not have preview images
- make background preloading density-aware and keep a PNG fallback preload path

## Validation
- `npm.cmd test`
- `npm.cmd run build`
